### PR TITLE
help sass-loader find @-scoped npm package content

### DIFF
--- a/game/hud/src/index.scss
+++ b/game/hud/src/index.scss
@@ -40,7 +40,7 @@ body {
   // widgets
   @import './components/hud/BuildingOLD/index';
   // external scss
-  @import '@csegames/camelot-unchained/lib/components/Chat/index.scss';
+  @import '../node_modules/@csegames/camelot-unchained/lib/components/Chat/index.scss';
   .chat-window {
     position: relative;
     overflow: hidden;

--- a/game/hud/typings.json
+++ b/game/hud/typings.json
@@ -15,6 +15,6 @@
     "yargs-parser": "github:cumodsquad/Typings/yargs-parser/yargs-parser.d.ts"
   },
   "dependencies": {
-    "index": "github:gaearon/redux-thunk/index.d.ts"
+    "index": "github:reduxjs/redux-thunk/src/index.d.ts"
   }
 }


### PR DESCRIPTION
This is an ugly hack, but it gets this thing to compile